### PR TITLE
set idletimeout as read/write timeout for socket

### DIFF
--- a/src/reqs.c
+++ b/src/reqs.c
@@ -1489,6 +1489,11 @@ void handle_connection (int fd)
                         establish_http_connection (connptr, request);
         }
 
+        set_readtimeout(connptr->client_fd, config.idletimeout);
+        set_readtimeout(connptr->server_fd, config.idletimeout);
+        set_writetimeout(connptr->client_fd, config.idletimeout);
+        set_writetimeout(connptr->server_fd, config.idletimeout);
+
         if (process_client_headers (connptr, hashofheaders) < 0) {
                 update_stats (STAT_BADCONN);
                 goto fail;

--- a/src/reqs.c
+++ b/src/reqs.c
@@ -1394,6 +1394,9 @@ void handle_connection (int fd)
                 close (fd);
                 return;
         }
+        
+        set_readtimeout(connptr->client_fd, config.idletimeout);
+        set_writetimeout(connptr->client_fd, config.idletimeout);
 
         if (check_acl (peer_ipaddr, peer_string, config.access_list) <= 0) {
                 update_stats (STAT_DENIED);
@@ -1489,9 +1492,7 @@ void handle_connection (int fd)
                         establish_http_connection (connptr, request);
         }
 
-        set_readtimeout(connptr->client_fd, config.idletimeout);
         set_readtimeout(connptr->server_fd, config.idletimeout);
-        set_writetimeout(connptr->client_fd, config.idletimeout);
         set_writetimeout(connptr->server_fd, config.idletimeout);
 
         if (process_client_headers (connptr, hashofheaders) < 0) {

--- a/src/sock.c
+++ b/src/sock.c
@@ -163,6 +163,24 @@ int socket_blocking (int sock)
 }
 
 /*
+ * set the socket 's read timeout -hanbaga
+ */
+int set_readtimeout(int sock, int timeout)
+{
+        assert (sock >= 0);
+        return setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const char*)&timeout, sizeof(int));
+}
+
+/*
+ * set the socket 's write timeout -hanbaga
+ */
+int set_writetimeout(int sock, int timeout)
+{
+        assert (sock >= 0);
+        return setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const char*)&timeout, sizeof(int));
+}
+
+/*
  * Start listening to a socket. Create a socket with the selected port.
  * The size of the socket address will be returned to the caller through
  * the pointer, while the socket is returned as a default return.

--- a/src/sock.c
+++ b/src/sock.c
@@ -168,7 +168,12 @@ int socket_blocking (int sock)
 int set_readtimeout(int sock, int timeout)
 {
         assert (sock >= 0);
-        return setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const char*)&timeout, sizeof(int));
+
+        struct timeval tv;
+        tv.tv_sec  = timeout;
+        tv.tv_usec = 0;
+
+        return setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const char*)&tv, sizeof(struct timeval));
 }
 
 /*
@@ -177,7 +182,12 @@ int set_readtimeout(int sock, int timeout)
 int set_writetimeout(int sock, int timeout)
 {
         assert (sock >= 0);
-        return setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, (const char*)&timeout, sizeof(int));
+
+        struct timeval tv;
+        tv.tv_sec  = timeout;
+        tv.tv_usec = 0;
+        
+        return setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, (const char*)&tv, sizeof(struct timeval));
 }
 
 /*

--- a/src/sock.h
+++ b/src/sock.h
@@ -31,6 +31,9 @@
 extern int opensock (const char *host, int port, const char *bind_to);
 extern int listen_sock (uint16_t port, socklen_t * addrlen);
 
+extern int set_readtimeout(int sock, int timeout);
+extern int set_writetimeout(int sock, int timeout);
+
 extern int socket_nonblocking (int sock);
 extern int socket_blocking (int sock);
 


### PR DESCRIPTION
recv function blocked when handle process_server_headers. 

(gdb) bt
#0 0x00000037b46e96b2 in recv () from /lib64/libc.so.6
#1 0x00000000004060c7 in recv (fd=7, whole_buffer=0x7fff12796830) at /usr/include/bits/socket2.h:45
#2 readline (fd=7, whole_buffer=0x7fff12796830) at network.c:167
#3 0x000000000040774d in process_server_headers (fd=) at reqs.c:966
#4 handle_connection (fd=) at reqs.c:1498
#5 0x0000000000402e05 in child_main (ptr=0x7f65b2a9f0fc) at child.c:237
#6 child_make (ptr=0x7f65b2a9f0fc) at child.c:296
#7 0x0000000000402fe2 in child_main_loop () at child.c:414
#8 0x0000000000409219 in main (argc=, argv=0x7fff127969d8) at main.c:462

I think need set idle_timeout as socket receive time-out also.  the solution.  please review it.
